### PR TITLE
Typo update for a jupyter notebook 

### DIFF
--- a/source-code/api-design/positional_vs_keyword_arguments.ipynb
+++ b/source-code/api-design/positional_vs_keyword_arguments.ipynb
@@ -372,7 +372,7 @@
    "id": "f08a6028-76e5-486d-a492-191f32815021",
    "metadata": {},
    "source": [
-    "The overhead of calling a function with keyword arguments is higher than withoug, as illustrated below."
+    "The overhead of calling a function with keyword arguments is higher than without, as illustrated below."
    ]
   },
   {

--- a/source-code/api-design/positional_vs_keyword_arguments.ipynb
+++ b/source-code/api-design/positional_vs_keyword_arguments.ipynb
@@ -354,7 +354,7 @@
    "id": "9ebb6221-2685-442d-8f7b-c362f755672d",
    "metadata": {},
    "source": [
-    "Indeed, why would you bother?  Essentially, there are two reaoons:\n",
+    "Indeed, why would you bother?  Essentially, there are two reasons:\n",
     "1. overhead of function calls, and\n",
     "1. maintenance."
    ]

--- a/source-code/api-design/positional_vs_keyword_arguments.ipynb
+++ b/source-code/api-design/positional_vs_keyword_arguments.ipynb
@@ -460,9 +460,9 @@
    "id": "56567790-2973-49bb-ab43-ce2e01d6464c",
    "metadata": {},
    "source": [
-    "Although keyword arguments are convenient and can make your code more robust since using them reduces the probability of mixing up arguments since you don't have to remember the order, this approach amkes maintaining the functions themselves a bit harder.\n",
+    "Although keyword arguments are convenient and can make your code more robust since using them reduces the probability of mixing up arguments since you don't have to remember the order, this approach makes maintaining the functions themselves a bit harder.\n",
     "\n",
-    "If the caller of the function uses keyword arguments and you change the name of a function argument, the function call will result in a runtime error.  The caller will have to adapt her code according to the changes you made.\n",
+    "If the caller of the function uses keyword arguments and you change the name of a function argument, the function call will result in a runtime error.  The caller will have to adapt its code according to the changes you made.\n",
     "\n",
     "Calling a function with positional arguments where possible avoids this issue.\n",
     "\n",


### PR DESCRIPTION
## Summary by Sourcery

Fix several typos and improve pronoun usage in the positional_vs_keyword_arguments Jupyter notebook

Documentation:
- Correct 'reaoons' to 'reasons', 'withoug' to 'without', and 'amkes' to 'makes'
- Replace gendered pronoun 'her' with neutral 'its' in notebook examples