### PR TITLE
Update state_machine_design_pattern.ipynb

### DIFF
--- a/source-code/design-patterns/state_machine_design_pattern.ipynb
+++ b/source-code/design-patterns/state_machine_design_pattern.ipynb
@@ -91,7 +91,7 @@
    "id": "e43ff767-437f-4d10-b4ef-d205be93a284",
    "metadata": {},
    "source": [
-    "Since a lot of things can go wrong, it is useful to define a number of exceptions.  The are all derived from an abstract base class `ExperimentException` to ensure that they can be captured easily."
+    "Since a lot of things can go wrong, it is useful to define a number of exceptions.  They are all derived from an abstract base class `ExperimentException` to ensure that they can be captured easily."
    ]
   },
   {


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Fix typo in exceptions description from "The are all derived" to "They are all derived".