### PR TITLE
Update functional_programming_style.ipynb

### DIFF
--- a/source-code/functional-programming/functional_programming_style.ipynb
+++ b/source-code/functional-programming/functional_programming_style.ipynb
@@ -238,7 +238,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "When using the `map` function, a common tasks is to do a computation involving a specific object attribute.  Consider the data class `Person`.  You would like to compute the average age of people in a list."
+    "When using the `map` function, a common task is to do a computation involving a specific object attribute.  Consider the data class `Person`.  You would like to compute the average age of people in a list."
    ]
   },
   {
@@ -298,7 +298,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "However, this is such a common pattern that the Python standard library has a function for it.  This function also has the advantage that the attribute to be extracted is specified as a string, and hcnce can be computed."
+    "However, this is such a common pattern that the Python standard library has a function for it.  This function also has the advantage that the attribute to be extracted is specified as a string, and hence can be computed."
    ]
   },
   {


### PR DESCRIPTION
## Summary by Sourcery

Fix minor typos in the functional programming style tutorial notebook

Documentation:
- Correct the phrase 'common tasks' to 'common task'
- Fix spelling of 'hcnce' to 'hence'